### PR TITLE
QUIC

### DIFF
--- a/QUIC/Dockerfile
+++ b/QUIC/Dockerfile
@@ -1,0 +1,6 @@
+FROM handsonsecurity/seed-ubuntu:large
+
+RUN apt-get update && apt-get install -y python3-pip
+
+COPY requirements.txt /requirements.txt
+RUN pip3 install --no-cache-dir -r /requirements.txt

--- a/QUIC/docker-compose.yml
+++ b/QUIC/docker-compose.yml
@@ -1,0 +1,80 @@
+services:
+    VPN_Client:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: vpnproject/seed-ubuntu:large
+        container_name: QUIC-client-10.9.0.5
+        tty: true
+        cap_add:
+                - ALL
+        devices:
+                - "/dev/net/tun:/dev/net/tun"
+        volumes:
+                - ./volumes:/volumes
+
+        networks:
+            net-10.9.0.0:
+                ipv4_address: 10.9.0.5
+        command: bash -c "
+                     tail -f /dev/null
+                 "
+
+    Host1:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: vpnproject/seed-ubuntu:large
+        container_name: QUIC-host-192.168.60.7
+        tty: true
+        cap_add:
+                - ALL
+        networks:
+            net-192.168.60.0:
+                ipv4_address: 192.168.60.7
+        command: bash -c "
+                      ip route del default  &&
+                      ip route add default via 192.168.60.11  &&
+                      /etc/init.d/openbsd-inetd start &&
+                      tail -f /dev/null
+                 "
+
+    Router:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        image: vpnproject/seed-ubuntu:large
+        container_name: QUIC-server-router
+        tty: true
+        cap_add:
+                - ALL
+        devices:
+                - "/dev/net/tun:/dev/net/tun"
+        sysctls:
+                - net.ipv4.ip_forward=1
+        volumes:
+          - ./volumes:/volumes
+        networks:
+            net-10.9.0.0:
+                ipv4_address: 10.9.0.11
+            net-192.168.60.0:
+                ipv4_address: 192.168.60.11
+        command: bash -c "
+                      ip route del default  &&
+                      ip route add default via 10.9.0.1 &&
+                      tail -f /dev/null
+                 "
+
+networks:
+    net-192.168.60.0:
+        name: net-192.168.60.0
+        ipam:
+            config:
+                - subnet: 192.168.60.0/24
+
+    net-10.9.0.0:
+        name: net-10.9.0.0
+        ipam:
+            config:
+                - subnet: 10.9.0.0/24
+

--- a/QUIC/requirements.txt
+++ b/QUIC/requirements.txt
@@ -1,0 +1,3 @@
+scapy~=2.6.1
+cryptography~=44.0.2
+aioquic~=1.2.0

--- a/QUIC/volumes/client/client.py
+++ b/QUIC/volumes/client/client.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+import struct
+import fcntl
+from scapy.all import *
+from aioquic.asyncio import connect
+from aioquic.quic.configuration import QuicConfiguration
+from shared.create_tun import createTun
+
+# TUN setup
+TUNSETIFF = 0x400454ca
+IFF_TUN   = 0x0001
+IFF_TAP   = 0x0002
+IFF_NO_PI = 0x1000
+
+ifname, tun = createTun(TUNSETIFF, IFF_TUN, IFF_NO_PI)
+os.system(f"ip addr add 192.168.53.99/24 dev {ifname}")
+os.system(f"ip link set dev {ifname} up")
+os.system(f"ip route add 192.168.60.0/24 dev {ifname}")
+
+async def recv_from_server(reader):
+    while True:
+        data = await reader.read(2048)
+        if not data:
+            print("Server closed connection.")
+            os._exit(1)
+        pkt = IP(data)
+        print(f"From server <==: {pkt.src} --> {pkt.dst}")
+        os.write(tun, data)
+
+def tun_read_cb(writer):
+    packet = os.read(tun, 2048)
+    pkt = IP(packet)
+    print(f"From tun ==>: {pkt.src} --> {pkt.dst}")
+    writer.write(packet)
+
+async def vpn_client():
+    configuration = QuicConfiguration(
+        is_client=True,
+        verify_mode=False
+    )
+
+    async with connect("10.9.0.11", 4433, configuration=configuration) as connection:
+        # quic = connection._quic
+        # stream_id = quic.get_next_available_stream_id()
+        reader, writer = await connection.create_stream()
+
+        loop = asyncio.get_running_loop()
+        loop.add_reader(tun, tun_read_cb, writer)
+
+        await recv_from_server(reader)  # Keep reading server
+
+if __name__ == "__main__":
+    asyncio.run(vpn_client())

--- a/QUIC/volumes/server/generate_cert.py
+++ b/QUIC/volumes/server/generate_cert.py
@@ -1,0 +1,49 @@
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa, ec
+from cryptography.hazmat.backends import default_backend
+import datetime
+
+def generate_self_signed_cert():
+    # Generate private key (ECDSA for faster QUIC, or RSA if you want)
+    private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    # private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+
+    # Create a self-signed cert
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, u"AU"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"NSW"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, u"Sydney"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"UTS"),
+        x509.NameAttribute(NameOID.COMMON_NAME, u"10.9.0.11"),
+    ])
+
+    cert = x509.CertificateBuilder()\
+        .subject_name(subject)\
+        .issuer_name(issuer)\
+        .public_key(private_key.public_key())\
+        .serial_number(x509.random_serial_number())\
+        .not_valid_before(datetime.datetime.utcnow())\
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=365))\
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(u"10.9.0.11")]),
+            critical=False,
+        )\
+        .sign(private_key, hashes.SHA256(), default_backend())
+
+    # Serialize to PEM format (bytes)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption()
+    )
+
+    with open("cert.pem", "wb") as cert_file:
+        cert_file.write(cert_pem)
+
+    with open("key.pem", "wb") as key_file:
+        key_file.write(key_pem)
+
+

--- a/QUIC/volumes/server/server.py
+++ b/QUIC/volumes/server/server.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+import struct
+import fcntl
+from scapy.all import *
+from aioquic.asyncio import serve
+from aioquic.quic.configuration import QuicConfiguration
+from shared.create_tun import createTun
+from generate_cert import generate_self_signed_cert
+
+# TUN setup
+TUNSETIFF = 0x400454ca
+IFF_TUN   = 0x0001
+IFF_TAP   = 0x0002
+IFF_NO_PI = 0x1000
+TUN_IP = "192.168.53.98"
+SERVER_IP = "10.9.0.11"
+QUIC_PORT = 4433
+
+
+ifname, tun = createTun(TUNSETIFF, IFF_TUN, IFF_NO_PI)
+os.system(f"ip addr add {TUN_IP}/24 dev {ifname}")
+os.system(f"ip link set dev {ifname} up")
+
+class VPNServerProtocol:
+    def __init__(self, reader, writer):
+        self.reader = reader
+        self.writer = writer
+
+    async def recv_from_client(self):
+        while True:
+            data = await self.reader.read(2048)
+            if not data:
+                print("Client closed connection.")
+                os._exit(1)
+            pkt = IP(data)
+            print(f"From client <==: {pkt.src} --> {pkt.dst}")
+            os.write(tun, data)
+
+    def tun_read_cb(self):
+        packet = os.read(tun, 2048)
+        pkt = IP(packet)
+        print(f"From tun ==>: {pkt.src} --> {pkt.dst}")
+        self.writer.write(packet)
+
+    async def handle(self):
+        loop = asyncio.get_running_loop()
+        loop.add_reader(tun, self.tun_read_cb)
+        await self.recv_from_client()
+
+
+def stream_handler(reader, writer):
+    asyncio.create_task(VPNServerProtocol(reader, writer).handle())
+
+
+async def vpn_server():
+    generate_self_signed_cert()
+    configuration = QuicConfiguration(
+        is_client=False,
+    )
+    configuration.load_cert_chain(certfile="cert.pem", keyfile="key.pem")
+    server = await serve(
+        host=SERVER_IP,
+        port=QUIC_PORT,
+        configuration=configuration,
+        stream_handler=stream_handler,
+    )
+    print(f"QUIC VPN server established on IP {SERVER_IP} and port {QUIC_PORT}")
+    await asyncio.Future()
+
+if __name__ == "__main__":
+    asyncio.run(vpn_server())

--- a/QUIC/volumes/shared/create_tun.py
+++ b/QUIC/volumes/shared/create_tun.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import fcntl
+import struct
+import os
+
+def createTun(TUNSETIFF, IFF_TUN, IFF_NO_PI):
+    tun = os.open("/dev/net/tun", os.O_RDWR)
+    ifr = struct.pack('16sH', b'tun%d', IFF_TUN | IFF_NO_PI)
+    ifname_bytes = fcntl.ioctl(tun, TUNSETIFF, ifr)
+
+    # Get the interface name
+    ifname = ifname_bytes.decode('UTF-8')[:16].strip("\x00")
+    print("Interface Name: {}".format(ifname))
+    return ifname, tun
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ mkdir keys
 openssl genrsa -out keys/server_private.pem 2048
 openssl rsa -in keys/server_private.pem -outform PEM -pubout -out keys/server_public.pem
 
+# For the QUIC implementation, prefix container names with "QUIC-"
+
 # Validate no connectivity between client and internal host
 docker exec -it client-10.9.0.5 ping 192.168.60.7
 


### PR DESCRIPTION
Created new version of VPN using a QUIC implementation instead of UDP. QUIC also handles encryption so removes the RSA component of this version in order to not double encrypt (still something that could be done). There are some improvements that could be made, namely the server currently sends and receives everything from the same TUN interface, it could potentially be made to dynamically create them for different clients/workloads (e.g streaming, gaming, browsing) in order to facilitate better prioritisation, however that would be out of scope as theres only one client pinging in the demo.

Tested and confirmed that the implementation is functional